### PR TITLE
Fixed bug with core plugin tool_recycle_bin on constants declaration

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -31,9 +31,11 @@ defined('MOODLE_INTERNAL') || die();
 /**
  * File area/component/table name for online text submission assignment
  */
-define('ASSIGNSUBMISSION_ONLINEPOODLL_FILEAREA', 'submissions_onlinepoodll');
-define('ASSIGNSUBMISSION_ONLINEPOODLL_COMPONENT', 'assignsubmission_onlinepoodll');
-define('ASSIGNSUBMISSION_ONLINEPOODLL_CONFIG_COMPONENT', 'assignsubmission_onlinepoodll');
+if (!defined('ASSIGNSUBMISSION_ONLINEPOODLL_TABLE')) {
+    define('ASSIGNSUBMISSION_ONLINEPOODLL_TABLE', 'assignsubmission_onlinepoodl');
+    define('ASSIGNSUBMISSION_ONLINEPOODLL_COMPONENT', 'assignsubmission_onlinepoodll');
+    define('ASSIGNSUBMISSION_ONLINEPOODLL_FILEAREA', 'submissions_onlinepoodll');
+}
 define('ASSIGNSUBMISSION_ONLINEPOODLL_TABLE', 'assignsubmission_onlinepoodl');
 define('ASSIGNSUBMISSION_ONLINEPOODLL_WB_FILEAREA', 'onlinepoodll_backimage');
 


### PR DESCRIPTION
Hi Justin,

I discovered a bug with core plugin tool_recyclebin (Moodle 3.1) when running behat tests: 

And I delete "Test assign" activity # /app/apache2/htdocs/moodle/admin/tool/recyclebin/tests/behat/basic_functionality.feature:33
      PHP debug message/s found:

```
  Notice: Constant ASSIGNSUBMISSION_ONLINEPOODLL_FILEAREA already defined in /app/apache2/htdocs/moodle/mod/assign/submission/onlinepoodll/locallib.php on line 34


  Notice: Constant ASSIGNSUBMISSION_ONLINEPOODLL_COMPONENT already defined in /app/apache2/htdocs/moodle/mod/assign/submission/onlinepoodll/locallib.php on line 35


  Notice: Constant ASSIGNSUBMISSION_ONLINEPOODLL_TABLE already defined in /app/apache2/htdocs/moodle/mod/assign/submission/onlinepoodll/locallib.php on line 37
   (Exception)
```

recyclebin is using backup/restore API so it seems it must load the files from backups before loading locallib.php.

I applied the same logic already in those files to check if the constants exist before declaring them.
