### PR TITLE
Adding missing setType()

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -149,6 +149,7 @@ class assign_submission_onlinepoodll extends assign_submission_plugin {
 		}else{
 			$mform->addElement('hidden', 'backimage',$backimage);
 		}
+		$mform->setType('backimage', PARAM_INT);
 
 		
 		//board sizes
@@ -171,6 +172,7 @@ class assign_submission_onlinepoodll extends assign_submission_plugin {
 		}else{
 			$mform->addElement('hidden', 'assignsubmission_onlinepoodll_boardsize',$boardsize);
 		}
+		$mform->setType('assignsubmission_onlinepoodll_boardsize', PARAM_TEXT);
 
     }
     


### PR DESCRIPTION
We had some debugging warnings that setType() is missing for backimage. This patch fixes that. It is based off poodle3 branch.